### PR TITLE
Add direnv for gnbug

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+PATH_add .


### PR DESCRIPTION
@arunisaac WDYT of this addition?

If you have `direnv` installed/configured then this lets you `cd` into `gn-gemtext-threads` and `gnbug` will be available in your `PATH`.

So, instead of `./gnbug list` a user can drop the `./` and just do `gnbug list` when in the directory.

Maybe, we can support both? For those not using `direnv`.