### PR TITLE
gnbug: Add edit sub-command

### DIFF
--- a/README.gmi
+++ b/README.gmi
@@ -38,6 +38,11 @@ Only list issues assigned to pjotrp.
 ./gnbug list --assigned=pjotrp
 ```
 
+Edit an issue, say issue 9. This opens the relevant gemtext file in your favourite editor as defined by the EDITOR environment variable.
+```
+./gnbug edit 9
+```
+
 List issues that were created or updated in the last 3 days, in the last week or month respectively. The --since argument is passed directly to `git log`. Therefore, gnbug understands any --since argument that `git log` understands.
 ```
 ./gnubug news --since='3 days'

--- a/gnbug
+++ b/gnbug
@@ -230,5 +230,12 @@ terminal."
                                                                                     ")")))))))))
                                rcount
                                (issues)))))
+    ((_ "edit" issue-number)
+     (unless (getenv "EDITOR")
+       (error "Please set the EDITOR environment variable to your favorite editor. For example,
+export EDITOR=emacsclient"))
+     (invoke (getenv "EDITOR")
+             (issue-file (list-ref (issues)
+                                   (1- (string->number issue-number))))))))
 
 (apply main (command-line))

--- a/gnbug
+++ b/gnbug
@@ -209,22 +209,26 @@ terminal."
                             invalid-operand
                             '())))
        (format #t "~%total ~a~%"
-               (list-transduce (compose (tfilter (lambda (issue)
-                                                   (or (not (assq 'assigned args))
-                                                       (member (assq-ref args 'assigned)
-                                                               (issue-assigned issue)))))
-                                        (tlog (lambda (_ issue)
-                                                (format #t "~a ~a ~a~a~%"
-                                                        (issue-created-relative-date issue)
-                                                        (cyan (issue-creator issue))
-                                                        (issue-title issue)
-                                                        (match (issue-assigned issue)
-                                                          (() "")
-                                                          (assignees
-                                                           (magenta (string-append " (assigned: "
-                                                                                   (string-join assignees ", ")
-                                                                                   ")"))))))))
+               (list-transduce (compose (tenumerate 1)
+                                        (tfilter (match-lambda
+                                                   ((_ . issue)
+                                                    (or (not (assq 'assigned args))
+                                                        (member (assq-ref args 'assigned)
+                                                                (issue-assigned issue))))))
+                                        (tlog (match-lambda*
+                                                ((_ (index . issue))
+                                                 (format #t "~a ~a ~a ~a~a~%"
+                                                         (magenta (string-append "#" (number->string index)))
+                                                         (issue-created-relative-date issue)
+                                                         (cyan (issue-creator issue))
+                                                         (issue-title issue)
+                                                         (match (issue-assigned issue)
+                                                           (() "")
+                                                           (assignees
+                                                            (magenta (string-append " (assigned: "
+                                                                                    (string-join assignees ", ")
+                                                                                    ")")))))))))
                                rcount
-                               (issues)))))))
+                               (issues)))))
 
 (apply main (command-line))


### PR DESCRIPTION
I have added a new edit sub-command to gnbug. This makes it easier to
open up the relevant gemtext file without having to manually navigate
the filesystem.

Cheers!